### PR TITLE
ESROGUE-549: document numDest scaling; bump axi-soc-ultra-plus-core

### DIFF
--- a/firmware/targets/SimpleZcu216Example/BuildYoctoProject.sh
+++ b/firmware/targets/SimpleZcu216Example/BuildYoctoProject.sh
@@ -10,6 +10,18 @@ hwType=XilinxZcu216
 numLane=2
 
 # Define number of DEST per DMA lane
+#
+# Soft default, NOT a hardware/driver limit: the DMA TDEST field is 8 bits
+# (256 dest/lane) and the kernel driver supports far more. The practical ceiling
+# is the on-board rogue TCP bridge's budget (~10 file descriptors + ~4 threads
+# per numLane*numDest stream). axi-soc-ultra-plus-core/BuildYoctoProject.sh
+# scales the systemd LimitNOFILE/LimitNPROC and kernel.threads-max with
+# numLane*numDest, and the bridge initializes PyRFdc before the stream loop so
+# libmetal's UIO fd stays below FD_SETSIZE (1024). High channel counts also need
+# rxBuffCnt raised (shared RX pool). See ESROGUE-549.
+#
+# Note: the Xilinx meta-layer enables tcf-agent (TCP port 1534) by default. If it
+# collides with your setup, disable it on the board: systemctl disable --now tcf-agent
 numDest=32
 
 # Define number of DMA TX/RX Buffers


### PR DESCRIPTION
## Summary
A user hit runtime failures after raising the AXI-Stream DMA destination count. `numDest=32` is a soft default, not a hardware/driver limit (8-bit TDEST = 256/lane; driver `DMA_MAX_DEST` = 4096); the real ceiling is the on-board rogue TCP bridge's fd/thread budget.

- **firmware/targets/SimpleZcu216Example/BuildYoctoProject.sh**: comment the `numDest=32` line explaining it is a soft default, the bridge fd/thread budget, the resource-limit scaling now done in axi-soc-ultra-plus-core, and the `tcf-agent` (TCP port 1534) workaround.
- Bump the `axi-soc-ultra-plus-core` submodule to the `ESROGUE-549` tip carrying the PyRFdc reorder + scaled `LimitNOFILE`/`LimitNPROC`/`threads-max`.

## Dependencies
- slaclab/axi-soc-ultra-plus-core#100 (submodule changes; this PR bumps to its `ESROGUE-549` tip)
- slaclab/rogue#1242 (the `select()` -> `poll()` fix that actually lifts the ~100-stream ceiling)

Once the upstream PRs merge, re-point the submodule to the merged SHA.

## Test plan
- [x] `bash -n` on the target `BuildYoctoProject.sh`
- [ ] Build/boot the default `numLane=2 numDest=32` image (regression)
- [ ] High-channel build with the upstream branches to validate scaling